### PR TITLE
Fix a memory leak after closing observed window.

### DIFF
--- a/Sources/KeyWindow/Internal/HostingWindowFinder.swift
+++ b/Sources/KeyWindow/Internal/HostingWindowFinder.swift
@@ -14,8 +14,10 @@ struct HostingWindowFinder: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        DispatchQueue.main.async { [weak view] in
-            self.callback(view?.window)
+        
+        let window = view.window
+        DispatchQueue.main.async { [weak window] in
+            self.callback(window)
         }
         return view
     }
@@ -29,8 +31,10 @@ struct HostingWindowFinder: NSViewRepresentable {
     func makeNSView(context: Self.Context) -> NSView {
         let view = NSView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        DispatchQueue.main.async { [weak view] in
-            self.callback(view?.window)
+        
+        let window = view.window
+        DispatchQueue.main.async { [weak window] in
+            self.callback(window)
         }
         return view
     }

--- a/Sources/KeyWindow/Internal/HostingWindowFinder.swift
+++ b/Sources/KeyWindow/Internal/HostingWindowFinder.swift
@@ -14,10 +14,8 @@ struct HostingWindowFinder: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        
-        let window = view.window
-        DispatchQueue.main.async { [weak window] in
-            self.callback(window)
+        DispatchQueue.main.async { [weak view] in
+            self.callback(view?.window)
         }
         return view
     }
@@ -31,10 +29,8 @@ struct HostingWindowFinder: NSViewRepresentable {
     func makeNSView(context: Self.Context) -> NSView {
         let view = NSView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        
-        let window = view.window
-        DispatchQueue.main.async { [weak window] in
-            self.callback(window)
+        DispatchQueue.main.async { [weak view] in
+            self.callback(view?.window)
         }
         return view
     }

--- a/Sources/KeyWindow/Internal/WindowObserver.swift
+++ b/Sources/KeyWindow/Internal/WindowObserver.swift
@@ -88,4 +88,32 @@ class WindowObserver: ObservableObject {
             #endif
         }
     }
+    
+    /// Gets all notifications, unwraps them, then calls `removeObserver` on each of them.
+    /// Also sets all observers to nil.
+    private func removeAllObservers() {
+        var notifications = [
+            becomeKeyObserver,
+            resignKeyObserver,
+        ]
+        
+        #if canImport(AppKit)
+        notifications.append(willCloseObserver)
+        #endif
+        
+        notifications
+            .compactMap { $0 }
+            .forEach(NotificationCenter.default.removeObserver(_:))
+        
+        becomeKeyObserver = nil
+        resignKeyObserver = nil
+        
+        #if canImport(AppKit)
+        willCloseObserver = nil
+        #endif
+    }
+    
+    deinit {
+        removeAllObservers()
+    }
 }


### PR DESCRIPTION
`makeUIView(context:)` in `HostingWindowFinder` has a weak reference to a new `UIView` instance, which causes memory leak (shown on image below) when window with view that has `.observeWindow()` modifier is deinitialized (closed).
![Instruments image with presente memory leak](https://user-images.githubusercontent.com/20259008/127814359-b3b88c81-2994-4b61-b2b0-c640def11f55.png)
 
 
Declaring window as separated property, then passing it to the closure looks like a valid fix for that issue (closing window is marked with a gray vertical mark on image below).

![Instruments image without any memory leak](https://user-images.githubusercontent.com/20259008/127814624-cde35a49-199a-4ab5-90de-9884ced85838.png)